### PR TITLE
Add full path to dependencies download

### DIFF
--- a/download_dependencies.ps1
+++ b/download_dependencies.ps1
@@ -1,8 +1,9 @@
 function Download($URL, $NAME){
 
-    (New-Object System.Net.WebClient).DownloadFile($URL, $NAME+".zip")
-    Expand-Archive -Path $NAME".zip" -Force
-    Remove-Item -Path $NAME".zip" -Force
+    $DEST=$PSScriptRoot+"\"+$NAME+".zip"
+    (New-Object System.Net.WebClient).DownloadFile($URL, $DEST)
+    Expand-Archive -Path $DEST -Force
+    Remove-Item -Path $DEST -Force
 
 }
 


### PR DESCRIPTION
PS's DownloadFile cmdlet was downloading to the desktop rather than the script directory, which broke the expand and remove actions when they couldn't find the file. Declared new var that concats script path and dependency name and then uses that for the remainder of actions.