### PR TITLE
Update dev.devstack.cc URL to HTTPS

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -56,7 +56,7 @@
             
             <div class="row" >
               <div class="col-sm-8" >
-                <a href="http://dev.deepstack.cc" target="_blank" class="btn btn-outline btn-xl js-scroll-trigger" style="margin: 10px;">DeepStack Dev Center</a>
+                <a href="https://dev.deepstack.cc" target="_blank" class="btn btn-outline btn-xl js-scroll-trigger" style="margin: 10px;">DeepStack Dev Center</a>
               </div>
               
             </div>


### PR DESCRIPTION
The Server/URL no longer responds to HTTP. Updating to use HTTPS instead.
Old: http://dev.devstack.cc
New: https://dev.devstack.cc